### PR TITLE
renamed clients to sockets

### DIFF
--- a/include/libKitsuneNetwork/abstract_server.h
+++ b/include/libKitsuneNetwork/abstract_server.h
@@ -27,7 +27,7 @@ namespace Kitsune
 namespace Network
 {
 class NetworkTrigger;
-class AbstractClient;
+class AbstractSocket;
 
 class AbstractServer : public Kitsune::Common::Thread
 {
@@ -35,11 +35,11 @@ public:
     AbstractServer();
     ~AbstractServer();
 
-    virtual AbstractClient* waitForIncomingConnection() = 0;
+    virtual AbstractSocket* waitForIncomingConnection() = 0;
     bool closeServer();
 
     uint64_t getNumberOfSockets();
-    AbstractClient* getSocket(const uint32_t pos);
+    AbstractSocket* getSocket(const uint32_t pos);
 
     // trigger-control
     void addAdditionalTrigger(NetworkTrigger* trigger);
@@ -50,7 +50,7 @@ protected:
 
     int m_serverSocket = 0;
     std::vector<NetworkTrigger*> m_trigger;
-    std::vector<AbstractClient*> m_sockets;
+    std::vector<AbstractSocket*> m_sockets;
 };
 
 } // namespace Network

--- a/include/libKitsuneNetwork/abstract_socket.h
+++ b/include/libKitsuneNetwork/abstract_socket.h
@@ -1,12 +1,13 @@
-#ifndef ABSTRACT_CLIENT_H
-#define ABSTRACT_CLIENT_H
 /**
- *  @file    abstract_client.h
+ *  @file    abstract_socket.h
  *
  *  @author  Tobias Anker <tobias.anker@kitsunemimi.moe>
  *
  *  @copyright MIT License
  */
+
+#ifndef ABSTRACT_SOCKET_H
+#define ABSTRACT_SOCKET_H
 
 #include <sys/types.h>
 #include <sys/socket.h>
@@ -33,11 +34,11 @@ namespace Network
 class NetworkTrigger;
 class CleanupThread;
 
-class AbstractClient : public Kitsune::Common::Thread
+class AbstractSocket : public Kitsune::Common::Thread
 {
 public:
-    AbstractClient();
-    ~AbstractClient();
+    AbstractSocket();
+    ~AbstractSocket();
 
     static Kitsune::Network::CleanupThread* m_cleanup;
 
@@ -47,14 +48,14 @@ public:
     void clearNetworkTrigger();
 
     bool sendMessage(const std::string &message);
-    bool sendMessage(const uint8_t *message,
+    bool sendMessage(const void *message,
                      const uint64_t numberOfBytes);
 
     bool closeSocket();
 
 protected:
     bool m_clientSide = false;
-    int m_clientSocket = 0;
+    int m_socket = 0;
 
     MessageRingBuffer m_recvBuffer;
     std::vector<NetworkTrigger*> m_trigger;
@@ -63,12 +64,18 @@ protected:
     bool waitForMessage();
 
 private:
-    virtual bool initClientSide() = 0;
-    virtual long recvData(int socket, void* bufferPosition, const size_t bufferSize, int flags) = 0;
-    virtual ssize_t sendData(int socket, const void* bufferPosition, const size_t bufferSize, int flags) = 0;
+    virtual bool initSocketSide() = 0;
+    virtual long recvData(int socket,
+                          void* bufferPosition,
+                          const size_t bufferSize,
+                          int flags) = 0;
+    virtual ssize_t sendData(int socket,
+                             const void* bufferPosition,
+                             const size_t bufferSize,
+                             int flags) = 0;
 };
 
 } // namespace Network
 } // namespace Kitsune
 
-#endif // ABSTRACT_CLIENT_H
+#endif // ABSTRACT_SOCKET_H

--- a/include/libKitsuneNetwork/network_trigger.h
+++ b/include/libKitsuneNetwork/network_trigger.h
@@ -16,7 +16,7 @@ namespace Kitsune
 {
 namespace Network
 {
-class AbstractClient;
+class AbstractSocket;
 struct MessageRingBuffer;
 
 class NetworkTrigger
@@ -26,7 +26,7 @@ public:
     virtual ~NetworkTrigger();
 
     virtual uint64_t runTask(MessageRingBuffer& recvBuffer,
-                             AbstractClient* client) = 0;
+                             AbstractSocket* socket) = 0;
 };
 
 } // namespace Network

--- a/include/libKitsuneNetwork/tcp/tcp_server.h
+++ b/include/libKitsuneNetwork/tcp/tcp_server.h
@@ -22,7 +22,7 @@ public:
     ~TcpServer();
 
     bool initSocket(const uint16_t port);
-    AbstractClient* waitForIncomingConnection();
+    AbstractSocket* waitForIncomingConnection();
 
 private:
     struct sockaddr_in m_server;

--- a/include/libKitsuneNetwork/tcp/tcp_socket.h
+++ b/include/libKitsuneNetwork/tcp/tcp_socket.h
@@ -1,39 +1,39 @@
 /**
- *  @file    tcp_client.h
+ *  @file    tcp_socket.h
  *
  *  @author  Tobias Anker <tobias.anker@kitsunemimi.moe>
  *
  *  @copyright MIT License
  */
 
-#ifndef TCP_CLIENT_H
-#define TCP_CLIENT_H
+#ifndef TCP_SOCKET_H
+#define TCP_SOCKET_H
 
 #include <netinet/in.h>
 #include <netdb.h>
 #include <netinet/tcp.h>
 
-#include <abstract_client.h>
+#include <abstract_socket.h>
 
 namespace Kitsune
 {
 namespace Network
 {
 
-class TcpClient : public AbstractClient
+class TcpSocket : public AbstractSocket
 {
 public:
-    TcpClient(const std::string address,
+    TcpSocket(const std::string address,
               const uint16_t port);
-    TcpClient(const int clientFd,
-              struct sockaddr_in client);
+    TcpSocket(const int socketFd,
+              struct sockaddr_in socket);
 
 private:
     std::string m_address = "";
     uint16_t m_port = 0;
-    sockaddr_in m_client;
+    sockaddr_in m_socketAddr;
 
-    bool initClientSide();
+    bool initSocketSide();
     long recvData(int socket, void* bufferPosition, const size_t bufferSize, int flags);
     ssize_t sendData(int socket, const void* bufferPosition, const size_t bufferSize, int flags);
 };
@@ -41,4 +41,4 @@ private:
 } // namespace Network
 } // namespace Kitsune
 
-#endif // TCP_CLIENT_H
+#endif // TCP_SOCKET_H

--- a/include/libKitsuneNetwork/tls_tcp/tls_tcp_server.h
+++ b/include/libKitsuneNetwork/tls_tcp/tls_tcp_server.h
@@ -1,5 +1,5 @@
 /**
- *  @file    tls_tcp_client.h
+ *  @file    tls_tcp_socket.h
  *
  *  @author  Tobias Anker <tobias.anker@kitsunemimi.moe>
  *
@@ -28,7 +28,7 @@ public:
     ~TlsTcpServer();
 
     bool initSocket(const uint16_t port);
-    AbstractClient* waitForIncomingConnection();
+    AbstractSocket* waitForIncomingConnection();
 
 private:
     struct sockaddr_in m_server;

--- a/include/libKitsuneNetwork/tls_tcp/tls_tcp_socket.h
+++ b/include/libKitsuneNetwork/tls_tcp/tls_tcp_socket.h
@@ -1,13 +1,13 @@
 ﻿/**
- *  @file    tls_tcp_client.h
+ *  @file    tls_tcp_socket.h
  *
  *  @author  Tobias Anker <tobias.anker@kitsunemimi.moe>
  *
  *  @copyright MIT License
  */
 
-#ifndef TLS_TCP_CLIENT_H
-#define TLS_TCP_CLIENT_H
+#ifndef TLS_TCP_SOCKET_H
+#define TLS_TCP_SOCKET_H
 
 #include <netinet/in.h>
 #include <netdb.h>
@@ -16,37 +16,37 @@
 #include <openssl/bio.h>
 #include <openssl/err.h>
 
-#include <abstract_client.h>
+#include <abstract_socket.h>
 
 namespace Kitsune
 {
 namespace Network
 {
 
-class TlsTcpClient : public AbstractClient
+class TlsTcpSocket : public AbstractSocket
 {
 public:
-    TlsTcpClient(const std::string address,
+    TlsTcpSocket(const std::string address,
                  const uint16_t port,
                  const std::string certFile,
                  const std::string keyFile);
-    TlsTcpClient(const int clientFd,
-                 struct sockaddr_in client,
+    TlsTcpSocket(const int socketFd,
+                 struct sockaddr_in socket,
                  const std::string certFile,
                  const std::string keyFile);
-    ~TlsTcpClient();
+    ~TlsTcpSocket();
 
 private:
     std::string m_address = "";
     uint16_t m_port = 0;
-    sockaddr_in m_client;
+    sockaddr_in m_socketAddr;
 
     SSL_CTX* m_ctx;
     SSL* m_ssl;
     std::string m_certFile = "";
     std::string m_keyFile = "";
 
-    bool initClientSide();
+    bool initSocketSide();
     long recvData(int, void* bufferPosition, const size_t bufferSize, int);
     ssize_t sendData(int, const void* bufferPosition, const size_t bufferSize, int);
 
@@ -59,4 +59,4 @@ private:
 } // namespace Network
 } // namespace Kitsune
 
-#endif // TLS_TCP_CLIENT_H
+#endif // TLS_TCP_SOCKET_H

--- a/include/libKitsuneNetwork/unix/unix_server.h
+++ b/include/libKitsuneNetwork/unix/unix_server.h
@@ -15,7 +15,7 @@ namespace Kitsune
 {
 namespace Network
 {
-class UnixClient;
+class UnixSocket;
 
 class UnixServer : public AbstractServer
 {
@@ -24,7 +24,7 @@ public:
     ~UnixServer();
 
     bool initSocket(const std::string socketFile);
-    AbstractClient* waitForIncomingConnection();
+    AbstractSocket* waitForIncomingConnection();
 
 private:
     struct sockaddr_un m_server;

--- a/include/libKitsuneNetwork/unix/unix_socket.h
+++ b/include/libKitsuneNetwork/unix/unix_socket.h
@@ -1,33 +1,33 @@
 /**
- *  @file    unix_client.h
+ *  @file    unix_socket.h
  *
  *  @author  Tobias Anker <tobias.anker@kitsunemimi.moe>
  *
  *  @copyright MIT License
  */
 
-#ifndef UNIX_CLIENT_H
-#define UNIX_CLIENT_H
+#ifndef UNIX_SOCKET_H
+#define UNIX_SOCKET_H
 
-#include <abstract_client.h>
+#include <abstract_socket.h>
 
 namespace Kitsune
 {
 namespace Network
 {
 
-class UnixClient : public AbstractClient
+class UnixSocket : public AbstractSocket
 {
 public:
-    UnixClient(const std::string socketFile);
-    UnixClient(const int clientFd,
-               sockaddr_un client);
+    UnixSocket(const std::string socketFile);
+    UnixSocket(const int socketFd,
+               sockaddr_un socket);
 
 private:
     std::string m_socketFile = "";
-    sockaddr_un m_client;
+    sockaddr_un m_socketAddr;
 
-    bool initClientSide();
+    bool initSocketSide();
 
     long recvData(int socket, void* bufferPosition, const size_t bufferSize, int flags);
     ssize_t sendData(int socket, const void* bufferPosition, const size_t bufferSize, int flags);
@@ -36,4 +36,4 @@ private:
 } // namespace Network
 } // namespace Kitsune
 
-#endif // UNIX_CLIENT_H
+#endif // UNIX_SOCKET_H

--- a/src/abstract_server.cpp
+++ b/src/abstract_server.cpp
@@ -7,7 +7,7 @@
  */
 
 #include "abstract_server.h"
-#include <abstract_client.h>
+#include <abstract_socket.h>
 
 namespace Kitsune
 {
@@ -48,12 +48,12 @@ AbstractServer::getNumberOfSockets()
  *
  * @param pos position in the list
  *
- * @return tcp-client-pointer
+ * @return tcp-socket-pointer
  */
-AbstractClient*
+AbstractSocket*
 AbstractServer::getSocket(const uint32_t pos)
 {
-    AbstractClient* result = nullptr;
+    AbstractSocket* result = nullptr;
     mutexLock();
     if(pos < m_sockets.size()) {
         result = m_sockets.at(pos);
@@ -84,7 +84,7 @@ AbstractServer::clearTrigger()
 
 
 /**
- * close the tcp-server togester with all tcp-client, which are connected to the server
+ * close the tcp-server togester with all tcp-socket, which are connected to the server
  *
  * @return false, if already closed, else true
  */

--- a/src/cleanup_thread.cpp
+++ b/src/cleanup_thread.cpp
@@ -17,7 +17,7 @@
 #include <cinttypes>
 #include <unistd.h>
 
-#include <tcp/tcp_client.h>
+#include <tcp/tcp_socket.h>
 #include <iostream>
 
 namespace Kitsune
@@ -31,14 +31,14 @@ namespace Network
 CleanupThread::CleanupThread() {}
 
 /**
- * @brief CleanupThread::addClientForCleanup
- * @param client
+ * @brief CleanupThread::addSocketForCleanup
+ * @param socket
  */
 void
-CleanupThread::addClientForCleanup(AbstractClient *client)
+CleanupThread::addSocketForCleanup(AbstractSocket *socket)
 {
     mutexLock();
-    m_cleanupQueue.push(client);
+    m_cleanupQueue.push(socket);
     mutexUnlock();
 }
 
@@ -55,10 +55,10 @@ CleanupThread::run()
         mutexLock();
         if(m_cleanupQueue.size() > 0)
         {
-            AbstractClient* client = m_cleanupQueue.front();
+            AbstractSocket* socket = m_cleanupQueue.front();
             m_cleanupQueue.pop();
-            client->stop();
-            delete client;
+            socket->stop();
+            delete socket;
         }
         mutexUnlock();
     }

--- a/src/cleanup_thread.h
+++ b/src/cleanup_thread.h
@@ -17,20 +17,20 @@ namespace Kitsune
 {
 namespace Network
 {
-class AbstractClient;
+class AbstractSocket;
 
 class CleanupThread : public Kitsune::Common::Thread
 {
 public:
     CleanupThread();
 
-    void addClientForCleanup(AbstractClient *client);
+    void addSocketForCleanup(AbstractSocket *socket);
 
 protected:
     void run();
 
 private:
-    std::queue<AbstractClient*> m_cleanupQueue;
+    std::queue<AbstractSocket*> m_cleanupQueue;
 };
 
 } // namespace Network

--- a/src/src.pro
+++ b/src/src.pro
@@ -16,26 +16,26 @@ INCLUDEPATH += $$PWD \
                $$PWD/../include/libKitsuneNetwork
 
 HEADERS += \
-    ../include/libKitsuneNetwork/tcp/tcp_client.h \
     ../include/libKitsuneNetwork/tcp/tcp_server.h \
     ../include/libKitsuneNetwork/network_trigger.h \
     ../include/libKitsuneNetwork/message_ring_buffer.h \
     cleanup_thread.h \
-    ../include/libKitsuneNetwork/abstract_client.h \
     ../include/libKitsuneNetwork/abstract_server.h \
     ../include/libKitsuneNetwork/unix/unix_server.h \
-    ../include/libKitsuneNetwork/unix/unix_client.h \
     ../include/libKitsuneNetwork/tls_tcp/tls_tcp_server.h \
-    ../include/libKitsuneNetwork/tls_tcp/tls_tcp_client.h
+    ../include/libKitsuneNetwork/tcp/tcp_socket.h \
+    ../include/libKitsuneNetwork/tls_tcp/tls_tcp_socket.h \
+    ../include/libKitsuneNetwork/unix/unix_socket.h \
+    ../include/libKitsuneNetwork/abstract_socket.h
 
 SOURCES += \
     network_trigger.cpp \
     cleanup_thread.cpp \
     tcp/tcp_server.cpp \
-    tcp/tcp_client.cpp \
     abstract_server.cpp \
-    abstract_client.cpp \
     unix/unix_server.cpp \
-    unix/unix_client.cpp \
     tls_tcp/tls_tcp_server.cpp \
-    tls_tcp/tls_tcp_client.cpp
+    tcp/tcp_socket.cpp \
+    tls_tcp/tls_tcp_socket.cpp \
+    unix/unix_socket.cpp \
+    abstract_socket.cpp

--- a/src/tcp/tcp_server.cpp
+++ b/src/tcp/tcp_server.cpp
@@ -7,7 +7,7 @@
  */
 
 #include <tcp/tcp_server.h>
-#include <tcp/tcp_client.h>
+#include <tcp/tcp_socket.h>
 #include <network_trigger.h>
 #include <iostream>
 
@@ -76,35 +76,35 @@ TcpServer::initSocket(const uint16_t port)
 /**
  * wait for new incoming tcp-connections
  *
- * @return new tcp-client-socket-pointer for the new incoming connection
+ * @return new tcp-socket-socket-pointer for the new incoming connection
  */
-AbstractClient* TcpServer::waitForIncomingConnection()
+AbstractSocket* TcpServer::waitForIncomingConnection()
 {
-    struct sockaddr_in client;
-    uint32_t length = sizeof(client);
+    struct sockaddr_in socket;
+    uint32_t length = sizeof(socket);
 
     //make new connection
-    int fd = accept(m_serverSocket, (struct sockaddr*)&client, &length);
+    int fd = accept(m_serverSocket, (struct sockaddr*)&socket, &length);
     if(fd < 0) {
         return nullptr;
     }
 
-    // create new client-object from file-descriptor
-    TcpClient* tcpClient = new TcpClient(fd, client);
+    // create new socket-object from file-descriptor
+    TcpSocket* tcpSocket = new TcpSocket(fd, socket);
     for(uint32_t i = 0; i < m_trigger.size(); i++) 
     {
-        tcpClient->addNetworkTrigger(m_trigger.at(i));
+        tcpSocket->addNetworkTrigger(m_trigger.at(i));
     }
 
-    // start new client-thread
-    tcpClient->start();
+    // start new socket-thread
+    tcpSocket->start();
 
     // append new socket to the list
     mutexLock();
-    m_sockets.push_back(tcpClient);
+    m_sockets.push_back(tcpSocket);
     mutexUnlock();
 
-    return tcpClient;
+    return tcpSocket;
 }
 
 } // namespace Network

--- a/src/tcp/tcp_socket.cpp
+++ b/src/tcp/tcp_socket.cpp
@@ -1,12 +1,12 @@
 /**
- *  @file    tcp_client.cpp
+ *  @file    tcp_socket.cpp
  *
  *  @author  Tobias Anker <tobias.anker@kitsunemimi.moe>
  *
  *  @copyright MIT License
  */
 
-#include <tcp/tcp_client.h>
+#include <tcp/tcp_socket.h>
 #include <iostream>
 #include <network_trigger.h>
 #include <cleanup_thread.h>
@@ -17,34 +17,34 @@ namespace Network
 {
 
 /**
- * constructor for the client-side of the tcp-connection
+ * constructor for the socket-side of the tcp-connection
  *
  * @param address ipv4-adress of the server
  * @param port port where the server is listen
  */
-TcpClient::TcpClient(const std::string address,
+TcpSocket::TcpSocket(const std::string address,
                      const uint16_t port)
-    : AbstractClient ()
+    : AbstractSocket ()
 {
     m_address = address;
     m_port = port;
     m_clientSide = true;
 
-    initClientSide();
+    initSocketSide();
 }
 
 /**
  * constructor for the server-side of the tcp-connection, which is called by the
  * tcp-server for each incoming connection
  *
- * @param clientFd file-descriptor of the client-socket
- * @param client address for the client
+ * @param socketFd file-descriptor of the socket-socket
+ * @param socket address for the socket
  */
-TcpClient::TcpClient(const int clientFd, sockaddr_in client)
-    : AbstractClient ()
+TcpSocket::TcpSocket(const int socketFd, sockaddr_in socket)
+    : AbstractSocket ()
 {
-    m_clientSocket = clientFd;
-    m_client = client;
+    m_socket = socketFd;
+    m_socketAddr = socket;
     m_clientSide = false;
 }
 
@@ -54,28 +54,28 @@ TcpClient::TcpClient(const int clientFd, sockaddr_in client)
  * @return false, if socket-creation or connection to the server failed, else true
  */
 bool
-TcpClient::initClientSide()
+TcpSocket::initSocketSide()
 {
-    struct sockaddr_in server;
+    struct sockaddr_in address;
     struct hostent* hostInfo;
     unsigned long addr;
 
     // create socket
-    m_clientSocket = socket(AF_INET, SOCK_STREAM, 0);
-    if(m_clientSocket < 0) {
+    m_socket = socket(AF_INET, SOCK_STREAM, 0);
+    if(m_socket < 0) {
         return false;
     }
 
     // set TCP_NODELAY for sure
     int optval = 1;
-    if(setsockopt(m_clientSocket, IPPROTO_TCP, TCP_NODELAY, &optval, sizeof(int)) < 0) {
+    if(setsockopt(m_socket, IPPROTO_TCP, TCP_NODELAY, &optval, sizeof(int)) < 0) {
         printf("Cannot set TCP_NODELAY option on listen socket (%s)\n", strerror(errno));
     }
 
     // set server-address
-    memset(&server, 0, sizeof(server));
+    memset(&address, 0, sizeof(address));
     if((addr = inet_addr(m_address.c_str())) != INADDR_NONE) {
-        memcpy((char*)&server.sin_addr, &addr, sizeof(addr));
+        memcpy((char*)&address.sin_addr, &addr, sizeof(addr));
     }
     else
     {
@@ -84,42 +84,44 @@ TcpClient::initClientSide()
         if(hostInfo == nullptr) {
             return false;
         }
-        memcpy((char*)&server.sin_addr, hostInfo->h_addr, hostInfo->h_length);
+        memcpy((char*)&address.sin_addr, hostInfo->h_addr, hostInfo->h_length);
     }
 
     // set other informations
-    server.sin_family = AF_INET;
-    server.sin_port = htons(m_port);
+    address.sin_family = AF_INET;
+    address.sin_port = htons(m_port);
 
     // create connection
-    if(connect(m_clientSocket, (struct sockaddr*)&server, sizeof(server)) < 0)
+    if(connect(m_socket, (struct sockaddr*)&address, sizeof(address)) < 0)
     {
         // TODO: correctly close socket
-        m_clientSocket = 0;
+        m_socket = 0;
         return false;
     }
+
+    m_socketAddr = address;
 
     return true;
 }
 
 /**
- * @brief TcpClient::recvData
+ * @brief TcpSocket::recvData
  *
  * @return
  */
 long
-TcpClient::recvData(int socket, void* bufferPosition, const size_t bufferSize, int flags)
+TcpSocket::recvData(int socket, void* bufferPosition, const size_t bufferSize, int flags)
 {
     return recv(socket, bufferPosition, bufferSize, flags);
 }
 
 /**
- * @brief TcpClient::sendData
+ * @brief TcpSocket::sendData
  *
  * @return
  */
 ssize_t
-TcpClient::sendData(int socket, const void* bufferPosition, const size_t bufferSize, int flags)
+TcpSocket::sendData(int socket, const void* bufferPosition, const size_t bufferSize, int flags)
 {
     return send(socket, bufferPosition, bufferSize, flags);
 }

--- a/src/tls_tcp/tls_tcp_server.cpp
+++ b/src/tls_tcp/tls_tcp_server.cpp
@@ -1,5 +1,5 @@
 /**
- *  @file    tls_tcp_client.cpp
+ *  @file    tls_tcp_socket.cpp
  *
  *  @author  Tobias Anker <tobias.anker@kitsunemimi.moe>
  *
@@ -7,7 +7,7 @@
  */
 
 #include <tls_tcp/tls_tcp_server.h>
-#include <tls_tcp/tls_tcp_client.h>
+#include <tls_tcp/tls_tcp_socket.h>
 #include <network_trigger.h>
 #include <iostream>
 
@@ -82,39 +82,39 @@ TlsTcpServer::initSocket(const uint16_t port)
 /**
  * wait for new incoming tcp-connections
  *
- * @return new tcp-client-socket-pointer for the new incoming connection
+ * @return new tcp-socket-socket-pointer for the new incoming connection
  */
-AbstractClient*
+AbstractSocket*
 TlsTcpServer::waitForIncomingConnection()
 {
-    struct sockaddr_in client;
-    uint32_t length = sizeof(client);
+    struct sockaddr_in socket;
+    uint32_t length = sizeof(socket);
 
     //make new connection
-    int fd = accept(m_serverSocket, (struct sockaddr*)&client, &length);
+    int fd = accept(m_serverSocket, (struct sockaddr*)&socket, &length);
     if(fd < 0) {
         return nullptr;
     }
 
-    // create new client-object from file-descriptor
-    TlsTcpClient* tcpClient = new TlsTcpClient(fd,
-                                               client,
+    // create new socket-object from file-descriptor
+    TlsTcpSocket* tcpSocket = new TlsTcpSocket(fd,
+                                               socket,
                                                m_certFile,
                                                m_keyFile);
     for(uint32_t i = 0; i < m_trigger.size(); i++) 
     {
-        tcpClient->addNetworkTrigger(m_trigger.at(i));
+        tcpSocket->addNetworkTrigger(m_trigger.at(i));
     }
 
-    // start new client-thread
-    tcpClient->start();
+    // start new socket-thread
+    tcpSocket->start();
 
     // append new socket to the list
     mutexLock();
-    m_sockets.push_back(tcpClient);
+    m_sockets.push_back(tcpSocket);
     mutexUnlock();
 
-    return tcpClient;
+    return tcpSocket;
 }
 
 } // namespace Network

--- a/src/unix/unix_server.cpp
+++ b/src/unix/unix_server.cpp
@@ -6,7 +6,7 @@
  *  @copyright MIT License
  */
 
-#include <unix/unix_client.h>
+#include <unix/unix_socket.h>
 #include <unix/unix_server.h>
 #include <network_trigger.h>
 #include <iostream>
@@ -68,36 +68,36 @@ UnixServer::initSocket(const std::string socketFile)
 /**
  * wait for new incoming unix-socket-connections
  *
- * @return new unix-client-socket-pointer for the new incoming connection
+ * @return new unix-socket-socket-pointer for the new incoming connection
  */
-AbstractClient*
+AbstractSocket*
 UnixServer::waitForIncomingConnection()
 {
-    struct sockaddr_un client;
-    uint32_t length = sizeof(client);
+    struct sockaddr_un socket;
+    uint32_t length = sizeof(socket);
 
     //make new connection
-    int fd = accept(m_serverSocket, (struct sockaddr*)&client, &length);
+    int fd = accept(m_serverSocket, (struct sockaddr*)&socket, &length);
     if(fd < 0) {
         return nullptr;
     }
 
-    // create new client-object from file-descriptor
-    UnixClient* unixClient = new UnixClient(fd, client);
+    // create new socket-object from file-descriptor
+    UnixSocket* unixSocket = new UnixSocket(fd, socket);
     for(uint32_t i = 0; i < m_trigger.size(); i++) 
     {
-        unixClient->addNetworkTrigger(m_trigger.at(i));
+        unixSocket->addNetworkTrigger(m_trigger.at(i));
     }
 
-    // start new client-thread
-    unixClient->start();
+    // start new socket-thread
+    unixSocket->start();
 
     // append new socket to the list
     mutexLock();
-    m_sockets.push_back(unixClient);
+    m_sockets.push_back(unixSocket);
     mutexUnlock();
 
-    return unixClient;
+    return unixSocket;
 }
 
 } // namespace Network

--- a/src/unix/unix_socket.cpp
+++ b/src/unix/unix_socket.cpp
@@ -1,12 +1,12 @@
 /**
- *  @file    unix_client.cpp
+ *  @file    unix_socket.cpp
  *
  *  @author  Tobias Anker <tobias.anker@kitsunemimi.moe>
  *
  *  @copyright MIT License
  */
 
-#include <unix/unix_client.h>
+#include <unix/unix_socket.h>
 #include <iostream>
 #include <network_trigger.h>
 #include <cleanup_thread.h>
@@ -17,31 +17,31 @@ namespace Network
 {
 
 /**
- * constructor for the client-side of the unix-socket-connection
+ * constructor for the socket-side of the unix-socket-connection
  *
  * @param address ipv4-adress of the server
  * @param port port where the server is listen
  */
-UnixClient::UnixClient(const std::string socketFile)
-    : AbstractClient ()
+UnixSocket::UnixSocket(const std::string socketFile)
+    : AbstractSocket ()
 {
     m_socketFile = socketFile;
     m_clientSide = true;
-    initClientSide();
+    initSocketSide();
 }
 
 /**
  * constructor for the server-side of the unix-socket-connection, which is called by the
  * unix-server for each incoming connection
  *
- * @param clientFd file-descriptor of the client-socket
- * @param client address for the client
+ * @param socketFd file-descriptor of the socket-socket
+ * @param socket address for the socket
  */
-UnixClient::UnixClient(const int clientFd, sockaddr_un client)
-    : AbstractClient ()
+UnixSocket::UnixSocket(const int socketFd, sockaddr_un socket)
+    : AbstractSocket ()
 {
-    m_clientSocket = clientFd;
-    m_client = client;
+    m_socket = socketFd;
+    m_socketAddr = socket;
     m_clientSide = false;
 }
 
@@ -51,13 +51,13 @@ UnixClient::UnixClient(const int clientFd, sockaddr_un client)
  * @return false, if socket-creation or connection to the server failed, else true
  */
 bool
-UnixClient::initClientSide()
+UnixSocket::initSocketSide()
 {
     struct sockaddr_un address;
 
     // create socket
-    m_clientSocket = socket(PF_LOCAL, SOCK_STREAM, 0);
-    if(m_clientSocket < 0) {
+    m_socket = socket(PF_LOCAL, SOCK_STREAM, 0);
+    if(m_socket < 0) {
         return false;
     }
 
@@ -66,34 +66,36 @@ UnixClient::initClientSide()
     strncpy(address.sun_path, m_socketFile.c_str(), m_socketFile.size());
 
     // create connection
-    if(connect(m_clientSocket, (struct sockaddr*)&address, sizeof(address)) < 0)
+    if(connect(m_socket, (struct sockaddr*)&address, sizeof(address)) < 0)
     {
         // TODO: correctly close socket
-        m_clientSocket = 0;
+        m_socket = 0;
         return false;
     }
+
+    m_socketAddr = address;
 
     return true;
 }
 
 /**
- * @brief UnixClient::recvData
+ * @brief UnixSocket::recvData
  *
  * @return
  */
 long
-UnixClient::recvData(int socket, void* bufferPosition, const size_t bufferSize, int flags)
+UnixSocket::recvData(int socket, void* bufferPosition, const size_t bufferSize, int flags)
 {
     return recv(socket, bufferPosition, bufferSize, flags);
 }
 
 /**
- * @brief UnixClient::sendData
+ * @brief UnixSocket::sendData
  *
  * @return
  */
 ssize_t
-UnixClient::sendData(int socket, const void* bufferPosition, const size_t bufferSize, int flags)
+UnixSocket::sendData(int socket, const void* bufferPosition, const size_t bufferSize, int flags)
 {
     return send(socket, bufferPosition, bufferSize, flags);
 }

--- a/tests/dummy_buffer.cpp
+++ b/tests/dummy_buffer.cpp
@@ -7,7 +7,7 @@
  */
 
 #include "dummy_buffer.h"
-#include <tcp/tcp_client.h>
+#include <tcp/tcp_socket.h>
 
 #include <buffering/data_buffer.h>
 #include <buffering/data_buffer_methods.h>
@@ -39,7 +39,7 @@ DummyBuffer::~DummyBuffer()
  */
 uint64_t
 DummyBuffer::runTask(MessageRingBuffer &recvBuffer,
-                     AbstractClient*)
+                     AbstractSocket*)
 {
     const uint8_t* dataPointer = getDataPointer(recvBuffer, recvBuffer.readWriteDiff);
     addDataToBuffer(m_buffer, dataPointer, recvBuffer.readWriteDiff);

--- a/tests/dummy_buffer.h
+++ b/tests/dummy_buffer.h
@@ -20,7 +20,7 @@ class DataBuffer;
 
 namespace Network
 {
-class AbstractClient;
+class AbstractSocket;
 struct MessageRingBuffer;
 
 class DummyBuffer : public NetworkTrigger
@@ -28,7 +28,7 @@ class DummyBuffer : public NetworkTrigger
 public:
     DummyBuffer();
     ~DummyBuffer();
-    uint64_t runTask(MessageRingBuffer &recvBuffer, AbstractClient*);
+    uint64_t runTask(MessageRingBuffer &recvBuffer, AbstractSocket*);
 
     uint64_t getNumberOfWrittenBytes();
     Common::DataBuffer* getBuffer();

--- a/tests/libKitsuneNetwork/tcp/tcp_socket_tcp_server_test.h
+++ b/tests/libKitsuneNetwork/tcp/tcp_socket_tcp_server_test.h
@@ -1,13 +1,13 @@
 /**
- *  @file    tcp_client_tcp_server_test.h
+ *  @file    tcp_socket_tcp_server_test.h
  *
  *  @author  Tobias Anker <tobias.anker@kitsunemimi.moe>
  *
  *  @copyright MIT License
  */
 
-#ifndef TCPCLIENT_TCPSERVER_TEST_H
-#define TCPCLIENT_TCPSERVER_TEST_H
+#ifndef TCPSOCKET_TCPSERVER_TEST_H
+#define TCPSOCKET_TCPSERVER_TEST_H
 
 #include <testing/unit_test.h>
 
@@ -17,13 +17,13 @@ namespace Network
 {
 
 class TcpServer;
-class TcpClient;
+class TcpSocket;
 class DummyBuffer;
 
-class TcpClient_TcpServer_Test : public Kitsune::Common::UnitTest
+class TcpSocket_TcpServer_Test : public Kitsune::Common::UnitTest
 {
 public:
-    TcpClient_TcpServer_Test();
+    TcpSocket_TcpServer_Test();
 
 private:
     void initTestCase();
@@ -33,12 +33,12 @@ private:
     void cleanupTestCase();
 
     TcpServer* m_server = nullptr;
-    TcpClient* m_clientClientSide = nullptr;
-    TcpClient* m_clientServerSide = nullptr;
+    TcpSocket* m_socketSocketSide = nullptr;
+    TcpSocket* m_socketServerSide = nullptr;
     DummyBuffer* m_buffer = nullptr;
 };
 
 } // namespace Network
 } // namespace Kitsune
 
-#endif // TCPCLIENT_TCPSERVER_TEST_H
+#endif // TCPSOCKET_TCPSERVER_TEST_H

--- a/tests/libKitsuneNetwork/tls_tcp/tls_tcp_socket_tls_tcp_server_test.h
+++ b/tests/libKitsuneNetwork/tls_tcp/tls_tcp_socket_tls_tcp_server_test.h
@@ -1,13 +1,13 @@
 /**
- *  @file    unix_client_unix_server_test.h
+ *  @file    tls_tcp_socket_tls_tcp_server_test.h
  *
  *  @author  Tobias Anker <tobias.anker@kitsunemimi.moe>
  *
  *  @copyright MIT License
  */
 
-#ifndef UNIX_CLIENT_UNIX_SERVER_TEST_H
-#define UNIX_CLIENT_UNIX_SERVER_TEST_H
+#ifndef TLSTCPSOCKET_TLSTCPSERVER_TEST_H
+#define TLSTCPSOCKET_TLSTCPSERVER_TEST_H
 
 #include <testing/unit_test.h>
 
@@ -16,14 +16,14 @@ namespace Kitsune
 namespace Network
 {
 
-class UnixServer;
-class UnixClient;
+class TlsTcpServer;
+class TlsTcpSocket;
 class DummyBuffer;
 
-class UnixClient_UnixServer_Test : public Kitsune::Common::UnitTest
+class TlsTcpSocket_TcpServer_Test : public Kitsune::Common::UnitTest
 {
 public:
-    UnixClient_UnixServer_Test();
+    TlsTcpSocket_TcpServer_Test();
 
 private:
     void initTestCase();
@@ -32,13 +32,13 @@ private:
     void checkBigDataTransfer();
     void cleanupTestCase();
 
-    UnixServer* m_server = nullptr;
-    UnixClient* m_clientClientSide = nullptr;
-    UnixClient* m_clientServerSide = nullptr;
+    TlsTcpServer* m_server = nullptr;
+    TlsTcpSocket* m_socketSocketSide = nullptr;
+    TlsTcpSocket* m_socketServerSide = nullptr;
     DummyBuffer* m_buffer = nullptr;
 };
 
 } // namespace Network
 } // namespace Kitsune
 
-#endif // UNIX_CLIENT_UNIX_SERVER_TEST_H
+#endif // TLSTCPSOCKET_TLSTCPSERVER_TEST_H

--- a/tests/libKitsuneNetwork/unix/unix_socket_unix_server_test.cpp
+++ b/tests/libKitsuneNetwork/unix/unix_socket_unix_server_test.cpp
@@ -1,16 +1,16 @@
 /**
- *  @file    tcp_client_tcp_server_test.cpp
+ *  @file    unix_socket_unix_server_test.cpp
  *
  *  @author  Tobias Anker <tobias.anker@kitsunemimi.moe>
  *
  *  @copyright MIT License
  */
 
-#include "tcp_client_tcp_server_test.h"
+#include "unix_socket_unix_server_test.h"
 #include <buffering/data_buffer.h>
 
-#include <tcp/tcp_server.h>
-#include <tcp/tcp_client.h>
+#include <unix/unix_socket.h>
+#include <unix/unix_server.h>
 #include <dummy_buffer.h>
 
 namespace Kitsune
@@ -18,8 +18,8 @@ namespace Kitsune
 namespace Network
 {
 
-TcpClient_TcpServer_Test::TcpClient_TcpServer_Test() :
-    Kitsune::Common::UnitTest("TcpClient_TcpServer_Test")
+UnixSocket_UnixServer_Test::UnixSocket_UnixServer_Test() :
+    Kitsune::Common::UnitTest("UnixSocket_UnixServer_Test")
 {
     initTestCase();
     checkConnectionInit();
@@ -32,28 +32,28 @@ TcpClient_TcpServer_Test::TcpClient_TcpServer_Test() :
  * initTestCase
  */
 void
-TcpClient_TcpServer_Test::initTestCase()
+UnixSocket_UnixServer_Test::initTestCase()
 {
     m_buffer = new DummyBuffer();
-    m_server = new TcpServer(m_buffer);
+    m_server = new UnixServer(m_buffer);
 }
 
 /**
  * checkConnectionInit
  */
 void
-TcpClient_TcpServer_Test::checkConnectionInit()
+UnixSocket_UnixServer_Test::checkConnectionInit()
 {
-    UNITTEST(m_server->initSocket(12345), true);
+    UNITTEST(m_server->initSocket("/tmp/sock.uds"), true);
     UNITTEST(m_server->start(), true);
-    m_clientClientSide = new TcpClient("127.0.0.1", 12345);
+    m_socketSocketSide = new UnixSocket("/tmp/sock.uds");
     usleep(10000);
 
     UNITTEST(m_server->getNumberOfSockets(), 1);
 
     if(m_server->getNumberOfSockets() == 1)
     {
-        m_clientServerSide = static_cast<TcpClient*>(m_server->getSocket(0));
+        m_socketServerSide = static_cast<UnixSocket*>(m_server->getSocket(0));
     }
 }
 
@@ -61,12 +61,12 @@ TcpClient_TcpServer_Test::checkConnectionInit()
  * checkLittleDataTransfer
  */
 void
-TcpClient_TcpServer_Test::checkLittleDataTransfer()
+UnixSocket_UnixServer_Test::checkLittleDataTransfer()
 {
     usleep(10000);
 
     std::string sendMessage("poipoipoi");
-    UNITTEST(m_clientClientSide->sendMessage(sendMessage), true);
+    UNITTEST(m_socketSocketSide->sendMessage(sendMessage), true);
     usleep(10000);
     UNITTEST(m_buffer->getNumberOfWrittenBytes(), 9);
 
@@ -87,13 +87,13 @@ TcpClient_TcpServer_Test::checkLittleDataTransfer()
  * checkBigDataTransfer
  */
 void
-TcpClient_TcpServer_Test::checkBigDataTransfer()
+UnixSocket_UnixServer_Test::checkBigDataTransfer()
 {
     std::string sendMessage = "poi";
-    UNITTEST(m_clientClientSide->sendMessage(sendMessage), true);
+    UNITTEST(m_socketSocketSide->sendMessage(sendMessage), true);
     for(uint32_t i = 0; i < 99999; i++)
     {
-        m_clientClientSide->sendMessage(sendMessage);
+        m_socketSocketSide->sendMessage(sendMessage);
     }
     usleep(10000);
     uint64_t totalIncom = m_buffer->getNumberOfWrittenBytes();
@@ -118,10 +118,10 @@ TcpClient_TcpServer_Test::checkBigDataTransfer()
  * cleanupTestCase
  */
 void
-TcpClient_TcpServer_Test::cleanupTestCase()
+UnixSocket_UnixServer_Test::cleanupTestCase()
 {
-    UNITTEST(m_clientServerSide->closeSocket(), true);
-    m_clientServerSide->closeSocket();
+    UNITTEST(m_socketServerSide->closeSocket(), true);
+    m_socketServerSide->closeSocket();
     UNITTEST(m_server->closeServer(), true);
 
     delete m_server;

--- a/tests/libKitsuneNetwork/unix/unix_socket_unix_server_test.h
+++ b/tests/libKitsuneNetwork/unix/unix_socket_unix_server_test.h
@@ -1,13 +1,13 @@
 /**
- *  @file    tls_tcp_client_tls_tcp_server_test.h
+ *  @file    unix_socket_unix_server_test.h
  *
  *  @author  Tobias Anker <tobias.anker@kitsunemimi.moe>
  *
  *  @copyright MIT License
  */
 
-#ifndef TLSTCPCLIENT_TLSTCPSERVER_TEST_H
-#define TLSTCPCLIENT_TLSTCPSERVER_TEST_H
+#ifndef UNIX_SOCKET_UNIX_SERVER_TEST_H
+#define UNIX_SOCKET_UNIX_SERVER_TEST_H
 
 #include <testing/unit_test.h>
 
@@ -16,14 +16,14 @@ namespace Kitsune
 namespace Network
 {
 
-class TlsTcpServer;
-class TlsTcpClient;
+class UnixServer;
+class UnixSocket;
 class DummyBuffer;
 
-class TlsTcpClient_TcpServer_Test : public Kitsune::Common::UnitTest
+class UnixSocket_UnixServer_Test : public Kitsune::Common::UnitTest
 {
 public:
-    TlsTcpClient_TcpServer_Test();
+    UnixSocket_UnixServer_Test();
 
 private:
     void initTestCase();
@@ -32,13 +32,13 @@ private:
     void checkBigDataTransfer();
     void cleanupTestCase();
 
-    TlsTcpServer* m_server = nullptr;
-    TlsTcpClient* m_clientClientSide = nullptr;
-    TlsTcpClient* m_clientServerSide = nullptr;
+    UnixServer* m_server = nullptr;
+    UnixSocket* m_socketSocketSide = nullptr;
+    UnixSocket* m_socketServerSide = nullptr;
     DummyBuffer* m_buffer = nullptr;
 };
 
 } // namespace Network
 } // namespace Kitsune
 
-#endif // TLSTCPCLIENT_TLSTCPSERVER_TEST_H
+#endif // UNIX_SOCKET_UNIX_SERVER_TEST_H

--- a/tests/main.cpp
+++ b/tests/main.cpp
@@ -6,13 +6,13 @@
  *  @copyright MIT License
  */
 
-#include <libKitsuneNetwork/tcp/tcp_client_tcp_server_test.h>
-#include <libKitsuneNetwork/unix/unix_client_unix_server_test.h>
-#include <libKitsuneNetwork/tls_tcp/tls_tcp_client_tls_tcp_server_test.h>
+#include <libKitsuneNetwork/tcp/tcp_socket_tcp_server_test.h>
+#include <libKitsuneNetwork/unix/unix_socket_unix_server_test.h>
+#include <libKitsuneNetwork/tls_tcp/tls_tcp_socket_tls_tcp_server_test.h>
 
 int main()
 {
-    Kitsune::Network::TcpClient_TcpServer_Test();
-    Kitsune::Network::UnixClient_UnixServer_Test();
-    Kitsune::Network::TlsTcpClient_TcpServer_Test();
+    Kitsune::Network::TcpSocket_TcpServer_Test();
+    Kitsune::Network::UnixSocket_UnixServer_Test();
+    Kitsune::Network::TlsTcpSocket_TcpServer_Test();
 }

--- a/tests/tests.pro
+++ b/tests/tests.pro
@@ -21,15 +21,15 @@ INCLUDEPATH += $$PWD \
 LIBS += -L../src -lKitsuneNetwork
 
 HEADERS += \
-    libKitsuneNetwork/tcp/tcp_client_tcp_server_test.h \
     dummy_buffer.h \
-    libKitsuneNetwork/unix/unix_client_unix_server_test.h \
-    libKitsuneNetwork/tls_tcp/tls_tcp_client_tls_tcp_server_test.h \
-    cert_init.h
+    cert_init.h \
+    libKitsuneNetwork/tcp/tcp_socket_tcp_server_test.h \
+    libKitsuneNetwork/tls_tcp/tls_tcp_socket_tls_tcp_server_test.h \
+    libKitsuneNetwork/unix/unix_socket_unix_server_test.h
 
 SOURCES += \
     main.cpp \
     dummy_buffer.cpp \
-    libKitsuneNetwork/tcp/tcp_client_tcp_server_test.cpp \
-    libKitsuneNetwork/unix/unix_client_unix_server_test.cpp \
-    libKitsuneNetwork/tls_tcp/tls_tcp_client_tls_tcp_server_test.cpp
+    libKitsuneNetwork/tcp/tcp_socket_tcp_server_test.cpp \
+    libKitsuneNetwork/tls_tcp/tls_tcp_socket_tls_tcp_server_test.cpp \
+    libKitsuneNetwork/unix/unix_socket_unix_server_test.cpp


### PR DESCRIPTION
Clients were renamed to sockets (TcpClient -> TcpSocket), because they are
created on client-side bei the user and an server-side by the server.
It could be confusing to have client-objects on server-side, so I renamed
them. Additionally I made some little cleanup of stuff I found while renaming.