### PR TITLE
update server-cleanup

### DIFF
--- a/include/libKitsunemimiNetwork/abstract_server.h
+++ b/include/libKitsunemimiNetwork/abstract_server.h
@@ -49,7 +49,7 @@ public:
     bool closeServer();
 
     uint64_t getNumberOfSockets();
-    AbstractSocket* getSocket(const uint32_t pos);
+    AbstractSocket* getPendingSocket();
 
 protected:
     void run();

--- a/src/abstract_server.cpp
+++ b/src/abstract_server.cpp
@@ -60,17 +60,17 @@ AbstractServer::getNumberOfSockets()
 /**
  * get a specific tcp-socket from the server
  *
- * @param pos position in the list
- *
  * @return tcp-socket-pointer
  */
 AbstractSocket*
-AbstractServer::getSocket(const uint32_t pos)
+AbstractServer::getPendingSocket()
 {
     AbstractSocket* result = nullptr;
     mutexLock();
-    if(pos < m_sockets.size()) {
-        result = m_sockets.at(pos);
+    if(m_sockets.size() > 0)
+    {
+        result = m_sockets.back();
+        m_sockets.pop_back();
     }
     mutexUnlock();
     return result;
@@ -102,15 +102,6 @@ AbstractServer::closeServer()
 
     // stop thread
     stopThread();
-
-    // close all connected sockets
-    mutexLock();
-    for(uint32_t i = 0; i < m_sockets.size(); i++)
-    {
-        m_sockets[i]->closeSocket();
-    }
-    m_sockets.clear();
-    mutexUnlock();
 
     LOG_INFO("Successfully closed server");
 

--- a/tests/libKitsunemimiNetwork/tcp/tcp_socket_tcp_server_test.cpp
+++ b/tests/libKitsunemimiNetwork/tcp/tcp_socket_tcp_server_test.cpp
@@ -89,8 +89,9 @@ TcpSocket_TcpServer_Test::checkConnectionInit()
 
     if(m_server->getNumberOfSockets() == 1)
     {
-        m_socketServerSide = static_cast<TcpSocket*>(m_server->getSocket(0));
+        m_socketServerSide = static_cast<TcpSocket*>(m_server->getPendingSocket());
         TEST_EQUAL(m_socketServerSide->getType(), AbstractSocket::TCP_SOCKET);
+        TEST_EQUAL(m_server->getNumberOfSockets(), 0);
     }
 }
 

--- a/tests/libKitsunemimiNetwork/tls_tcp/tls_tcp_socket_tls_tcp_server_test.cpp
+++ b/tests/libKitsunemimiNetwork/tls_tcp/tls_tcp_socket_tls_tcp_server_test.cpp
@@ -99,8 +99,9 @@ TlsTcpSocket_TlsTcpServer_Test::checkConnectionInit()
 
     if(m_server->getNumberOfSockets() == 1)
     {
-        m_socketServerSide = static_cast<TlsTcpSocket*>(m_server->getSocket(0));
+        m_socketServerSide = static_cast<TlsTcpSocket*>(m_server->getPendingSocket());
         TEST_EQUAL(m_socketServerSide->getType(), AbstractSocket::TLS_TCP_SOCKET);
+        TEST_EQUAL(m_server->getNumberOfSockets(), 0);
     }
 }
 

--- a/tests/libKitsunemimiNetwork/unix/unix_domain_socket_unix_domain_server_test.cpp
+++ b/tests/libKitsunemimiNetwork/unix/unix_domain_socket_unix_domain_server_test.cpp
@@ -89,8 +89,9 @@ UnixDomainSocket_UnixDomainServer_Test::checkConnectionInit()
 
     if(m_server->getNumberOfSockets() == 1)
     {
-        m_socketServerSide = static_cast<UnixDomainSocket*>(m_server->getSocket(0));
+        m_socketServerSide = static_cast<UnixDomainSocket*>(m_server->getPendingSocket());
         TEST_EQUAL(m_socketServerSide->getType(), AbstractSocket::UNIX_SOCKET);
+        TEST_EQUAL(m_server->getNumberOfSockets(), 0);
     }
 }
 


### PR DESCRIPTION
## Description

When a server is deleted, the sockets of the server are not closed anymore
to avoid problems in the session-layer.

## Related Issues

- https://github.com/tobiasanker/libKitsunemimiProjectCommon/issues/55

## How it was tested?

- updated unit-tests
